### PR TITLE
[BUGFIX] enable captcha on translated pages

### DIFF
--- a/Classes/Domain/Repository/ChallengeRepository.php
+++ b/Classes/Domain/Repository/ChallengeRepository.php
@@ -13,6 +13,7 @@ class ChallengeRepository extends Repository
     {
         $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
         $querySettings->setRespectStoragePage(false);
+        $querySettings->setRespectSysLanguage(false);
         $this->setDefaultQuerySettings($querySettings);
     }
 }


### PR DESCRIPTION
The ChallengeRepository is missing the query-setting to ignore the sys_language, which leads to the captcha not working on translated pages since challenges always have sys_language 0.