### PR TITLE
Check for valid base64 payload in challenge validation

### DIFF
--- a/Classes/Services/AltchaService.php
+++ b/Classes/Services/AltchaService.php
@@ -77,7 +77,13 @@ class AltchaService
 
     public function validate(string $payload): bool
     {
-        $payloadArray = json_decode(base64_decode($payload, true), true);
+        $decoded = base64_decode($payload, true);
+
+        if ($decoded === false) {
+            return false;
+        }
+
+        $payloadArray = json_decode($decoded, true);
 
         if ($payloadArray === null) {
             return false;


### PR DESCRIPTION
A client can potentially send an arbitrary solution payload.
If the client sends a payload that is not in base64 format, a type error occurs:

```
TypeError: json_decode(): Argument #1 ($json) must be of type string, bool given
```

This PR simply adds a check to the result of base64_decode() before passing it to json_decode.